### PR TITLE
Fix truncated --track flag help text in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ options:
                         Your prompt.
   -r {fast,medium,slow}, --reasoning-speed {fast,medium,slow}
                         The reasoning preset to use: fast/medium/slow. Defaults to medium.
-  -t, --track           Whether to return detailed information about the
+  -t, --track           Whether to return detailed information about the reasoning process.
 
 For more information, see: https://forge-api.nousresearch.com/docs
 ```

--- a/src/forge-api-demo/cli.py
+++ b/src/forge-api-demo/cli.py
@@ -29,7 +29,7 @@ def main():
                         choices=["fast", "medium", "slow"],
                         action="store")
     parser.add_argument("-t", "--track",
-                        help="Whether to return detailed information about the",
+                        help="Whether to return detailed information about the reasoning process.",
                         action="store_true")
     args = parser.parse_args()
 


### PR DESCRIPTION
The `-t/--track` flag description was truncated mid-sentence:

> Whether to return detailed information about the

This PR completes the sentence in both the source code and README:

> Whether to return detailed information about the reasoning process.

Fixes #3